### PR TITLE
Fix notification on failure

### DIFF
--- a/lib/guard/yard/server.rb
+++ b/lib/guard/yard/server.rb
@@ -41,7 +41,7 @@ module Guard
         end
         UI.error "[Guard::Yard] Error starting documentation server."
         Notifier.notify "[Guard::Yard] Server NOT started.",
-          :title => 'yard', :image => failed
+          :title => 'yard', :image => :failed
         false
       end
     end


### PR DESCRIPTION
There's an undefined variable that's called on failure. Instead of a variable, it should be a symbol.
