### PR TITLE
Do not show log/stderr of yard server

### DIFF
--- a/lib/guard/yard/server.rb
+++ b/lib/guard/yard/server.rb
@@ -18,7 +18,7 @@ module Guard
           Signal.trap('INT', 'IGNORE')
           Signal.trap('TSTP', 'IGNORE')
 
-          exec("yard server -p #{port}")
+          exec("yard server -p #{port} 2> /dev/null")
         end
         pid
       end


### PR DESCRIPTION
We usually use guard to run many task, messages from it's stdout is important. But logs from yard server are full of static files access which really meaningless for the most time.
