### PR TITLE
Update for Guard v1.1 Compatibility

### DIFF
--- a/lib/guard/yard.rb
+++ b/lib/guard/yard.rb
@@ -33,7 +33,7 @@ module Guard
       true
     end
 
-    def run_on_change(paths)
+    def run_on_changes(paths)
       UI.info "[Guard::Yard] Detected changes in #{paths.join(',')}."
       paths.each{ |path| document([path]) }
       UI.info "[Guard::Yard] Updated documentation for #{paths.join(',')}."


### PR DESCRIPTION
`run_on_change` is deprecated in Guard version 1.1. This change should bring the gem up to date with the latest version of Guard though I would recommend a version change to indicate that the version including this change should only be used with Guard 1.1 and above.
