### PR TITLE
Add ability to specify a server.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,7 +36,8 @@ Guard::Yard also provides some basic options for doc generation and running the 
 
 Available options:
 
-    :server => true         # Disable/Enable server
+    :enable_server => true  # Disable/Enable server. Defalt true
+    :server => "webrick"    # Specify which server to use
     :port => '8808'         # Port on which the server shoud run.
     :host => 'localhost'    # Host to which the server should bind.
     :stdout => 'yard.log'   # File in which to log the yard server output.

--- a/lib/guard/yard.rb
+++ b/lib/guard/yard.rb
@@ -11,8 +11,8 @@ module Guard
 
     def initialize(options = {})
       super
-      options[:server] = true unless options.key?(:server)
-      @server = options[:server] ? Server.new(options) : NoServer.new
+      options[:enable_server] = true unless options.key?(:enable_server)
+      @server = options[:enable_server] ? Server.new(options) : NoServer.new
     end
 
     def start

--- a/lib/guard/yard/server.rb
+++ b/lib/guard/yard/server.rb
@@ -9,6 +9,7 @@ module Guard
       def initialize(options = {})
         @port = options[:port] || '8808'
         @host = options[:host] || 'localhost'
+        @server = options[:server]
         @stdout = options[:stdout]
         @stderr = options[:stderr]
         @cli = options[:cli]
@@ -18,6 +19,7 @@ module Guard
         UI.info '[Guard::Yard] Starting YARD Documentation Server.'
 
         command = ["yard server -p #{port} -b #{host}"]
+        command << "-s #{@server}" if @server
         command << @cli if @cli
         command << "2> #{@stderr}" if @stderr
         command << "1> #{@stdout}" if @stdout


### PR DESCRIPTION
Scenario: Rails app using Puma.
config/puma.rb may do some rails specific stuff using the Rails namespace.
Server launch will fail unless Rails is loaded into memory, which is overkill.
This lets us specify webrick or any other server, which is a quick and dirty fix.
It may be better to allow full server options, but for simplicity's sake running
only server change is implemented to let us turn on webrick.