### PR TITLE
CHANGES.markdown: Repair markdown

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,8 @@
 # master (unreleased)
 
-* 2.2.0 (2016-12-28)
+* Add your change here
+
+# 2.2.0 (2016-12-28)
 
 * Added the server option `host`. (pascalturbo)
 


### PR DESCRIPTION
https://rubygems.org/gems/guard-yard shows the 2.2.0 is released.

This PR changes the changelog so that it shows 2.2.0 as released with its own heading.